### PR TITLE
Add xml and fodt.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
   "name": "ini Editor",
   "author": "death_au",
   "authorUrl": "https://github.com/deathau",
-  "description": "Edit ini files in Obsidian",
+  "description": "Edit ini, xml, and fodt files in Obsidian",
   "isDesktopOnly": false,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "minAppVersion": "0.10.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ini-obsidian",
-  "version": "0.0.2",
-  "description": "Edit ini files",
+  "version": "0.0.3",
+  "description": "Edit ini, xml, and fodt files",
   "main": "main.js",
   "scripts": {
     "install-deps": "npm install",

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,15 +13,26 @@ export default class IniPlugin extends Plugin {
 
     // register a custom icon
     this.addDocumentIcon("ini");
+    this.addDocumentIcon("xml");
+    this.addDocumentIcon("fodt");
 
     // register the view and extensions
     this.registerView("ini", this.iniViewCreator);
+    this.registerView("xml", this.xmlViewCreator);
+    this.registerView("fodt", this.xmlViewCreator);
+
     this.registerExtensions(["ini"], "ini");
+    this.registerExtensions(["xml"], "xml");
+    this.registerExtensions(["fodt"], "xml");
   }
 
   // function to create the view
   iniViewCreator = (leaf: WorkspaceLeaf) => {
     return new IniView(leaf);
+  }
+
+  xmlViewCreator = (leaf: WorkspaceLeaf) => {
+    return new XmlView(leaf);
   }
 
   // this function used the regular 'document' svg,
@@ -100,6 +111,7 @@ class IniView extends TextFileView {
 
   // confirms this view can accept ini extension
   canAcceptExtension(extension: string) {
+    
     return extension == 'ini';
   }
 
@@ -113,3 +125,83 @@ class IniView extends TextFileView {
     return "document-ini";
   }
 }
+
+// This is the custom view
+class XmlView extends TextFileView {
+
+  // internal code mirror instance
+  codeMirror: CodeMirror.Editor;
+
+  // this.contentEl is not exposed, so cheat a bit.
+  public get extContentEl(): HTMLElement {
+    // @ts-ignore
+    return this.contentEl;
+  }
+
+  // constructor
+  constructor(leaf: WorkspaceLeaf) {
+    super(leaf);
+
+    // create code mirror instance
+    this.codeMirror = CodeMirror(this.extContentEl, {
+      theme: "obsidian"
+    });
+    // register the changes event
+    this.codeMirror.on('changes', this.changed);
+  }
+
+  // when the view is resized, refresh CodeMirror (thanks Licat!)
+  onResize() {
+    this.codeMirror.refresh();
+  }
+
+  // called on code mirror changes
+  changed = async (instance: CodeMirror.Editor, changes: CodeMirror.EditorChangeLinkedList[]) => {
+    // request a debounced save in 2 seconds from now
+    this.requestSave();
+  }
+
+  // get the new file contents
+  getViewData = () => {
+    return this.codeMirror.getValue();
+  }
+
+  // set the file contents
+  setViewData = (data: string, clear: boolean) => {
+    if (clear) {
+      this.codeMirror.swapDoc(CodeMirror.Doc(data, "text/xml"))
+    }
+    else {
+      this.codeMirror.setValue(data);
+    }
+  }
+
+  // clear the view content
+  clear = () => {
+    this.codeMirror.setValue('');
+    this.codeMirror.clearHistory();
+  }
+
+  // gets the title of the document
+  getDisplayText() {
+    if (this.file) return this.file.basename;
+    else return "xml (no file)";
+  }
+
+  // confirms this view can accept ini extension
+  canAcceptExtension(extension: string) {
+
+    return extension == 'xml';
+  }
+
+  // the view type name
+  getViewType() {
+    return "xml";
+  }
+
+  // icon for the view
+  getIcon() {
+    return "document-xml";
+  }
+}
+

--- a/src/mode/properties/properties.js
+++ b/src/mode/properties/properties.js
@@ -74,5 +74,6 @@ CodeMirror.defineMode("properties", function() {
 
 CodeMirror.defineMIME("text/x-properties", "properties");
 CodeMirror.defineMIME("text/x-ini", "properties");
+CodeMirror.defineMIME("text/xml", "properties");
 
 });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -12,3 +12,18 @@
 .workspace-leaf-content[data-type="ini"] .cm-s-obsidian .cm-quote {
   color: var(--text-normal);
 }
+.workspace-leaf-content[data-type="xml"] .view-content {
+  font-family: var(--font-monospace);
+}
+.workspace-leaf-content[data-type="xml"] .cm-s-obsidian .cm-header {
+  color: var(--text-accent);
+  font-weight: 600;
+}
+.workspace-leaf-content[data-type="xml"] .cm-s-obsidian .cm-def {
+  color: var(--text-normal);
+  font-weight: 600;
+}
+.workspace-leaf-content[data-type="xml"] .cm-s-obsidian .cm-quote {
+  color: var(--text-normal);
+}
+


### PR DESCRIPTION
Modified the plugin and have tested it with Obsidian 12.5 to add a basic XML and FODT viewer. FODT is treated as a type of XML. Tests show that XML can be loaded into the editor.

I attempted an extension of CodeMirror rather than using your plugin as mentioned in https://github.com/deathau/txt-as-md-obsidian/issues/2.